### PR TITLE
SEO: per-page metadata, heading fixes, and alt text (4 locales)

### DIFF
--- a/docs/superpowers/plans/2026-08-12-seo-metadata-headings-alt.md
+++ b/docs/superpowers/plans/2026-08-12-seo-metadata-headings-alt.md
@@ -1,0 +1,1268 @@
+# SEO: Per-Page Metadata, Heading Hierarchy & Alt Text Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Adaptation note:** This frontend has no test framework (`frontend/package.json` has no `jest`/`vitest`/testing-library, no `"test"` script). "Verify" steps in this plan use `npm run build` + `curl`/`grep` against the built output instead of automated tests — the same method already used and proven in this session for the sitemap/robots/404 work.
+>
+> **Commit note:** The user commits everything themselves at the end, in one or a few batches of their own choosing. Each task below still lists a suggested "Commit" step (with a message) purely as a reference boundary/checkpoint — whoever executes this plan should stage and describe changes there, but must **not** run `git commit` automatically. Treat every "Commit" step as "stop here, this task is done" rather than an instruction to execute.
+
+**Goal:** Fix the three concrete SEO gaps found in an audit of `frontend/`: (1) every page shares one static `<title>`/`<meta description>`, causing Google to show duplicate/generic snippets for different pages (confirmed by the user's screenshot of `lyratech.com.mx/nosotros`); (2) heading tags (`h1`-`h6`) are duplicated, skipped, or missing on several pages; (3) several images have missing-context or hardcoded-English `alt` text on a 4-locale site.
+
+**Architecture:** Add per-page, per-locale `generateMetadata()` to each marketing page, backed by a new `metadata` namespace in the 4 `messages/*.json` files and two small shared helpers (`frontend/src/lib/site.ts` for the site's canonical domain, `frontend/src/lib/metadata.ts` for building `canonical`/`hreflang` alternates from the existing `pathnames` config). Fix headings and alt text in place, file by file, reusing existing translation keys where the content already exists and adding new small translation keys (in all 4 locales) where it doesn't.
+
+**Tech Stack:** Next.js 15 App Router, next-intl (locales: es/en/fr/de, `localePrefix: "never"` with per-locale `pathnames`), Tailwind.
+
+**Scope decision:** Phases 1-3 cover the 6 SEO-indexed marketing pages (home, about-us, services, portfolio, contact, legal) — these are what Google actually indexes and what the user's screenshot is about. Phase 4 covers the personal "digital business card" pages (`/ricardo`, `/ezzat`, `/galo`, `/maxime`, `/daniel-contreras`, `/daniel-queijeiro`, `/business-card`, `/ricardo-v3`, `/ricardo-v4`) — these are already blocked from indexing via `Disallow` rules added earlier this session in `frontend/src/app/robots.ts`, so fixing their headings/alt text is an accessibility nicety, not an SEO fix. Do Phase 4 last, and only if the user still wants it after Phases 1-3 ship.
+
+---
+
+## Phase 1 — Per-page, per-locale metadata
+
+### Task 1: Shared site-URL helper
+
+**Files:**
+- Create: `frontend/src/lib/site.ts`
+- Modify: `frontend/src/app/robots.ts`
+- Modify: `frontend/src/app/sitemap.ts`
+
+`robots.ts` and `sitemap.ts` each currently hardcode the same two lines (production URL fallback + `NEXT_PUBLIC_SITE_URL` resolution). Pulling them into one file avoids a third copy when metadata needs the same value.
+
+- [ ] **Step 1: Create the helper**
+
+```ts
+// frontend/src/lib/site.ts
+const productionSiteUrl = "https://lyratech.com.mx";
+
+export const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || productionSiteUrl).replace(/\/$/, "");
+export const isProductionSite = siteUrl === productionSiteUrl;
+```
+
+- [ ] **Step 2: Use it in `frontend/src/app/robots.ts`**
+
+Replace:
+```ts
+const productionUrl = "https://lyratech.com.mx";
+const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || productionUrl).replace(/\/$/, "");
+const isProduction = siteUrl === productionUrl;
+```
+with:
+```ts
+import { siteUrl, isProductionSite } from "@/lib/site";
+```
+and rename the two later usages of `isProduction` in that file to `isProductionSite`.
+
+- [ ] **Step 3: Use it in `frontend/src/app/sitemap.ts`**
+
+Replace:
+```ts
+const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || "https://lyratech.com.mx").replace(/\/$/, "");
+```
+with:
+```ts
+import { siteUrl } from "@/lib/site";
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `cd frontend && npx tsc --noEmit -p tsconfig.json`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/lib/site.ts frontend/src/app/robots.ts frontend/src/app/sitemap.ts
+git commit -m "refactor: share siteUrl/isProductionSite between robots.ts and sitemap.ts"
+```
+
+---
+
+### Task 2: `alternates` (canonical + hreflang) helper
+
+**Files:**
+- Create: `frontend/src/lib/metadata.ts`
+
+Every marketing page has a real, distinct URL per locale already (e.g. `/about-us` en, `/nosotros` es, `/ueber-uns` de, `/a-propos` fr — see `frontend/src/config.ts`). That means proper `hreflang` alternates are possible with no new routing work — just reading the existing `pathnames` map.
+
+- [ ] **Step 1: Write the helper**
+
+```ts
+// frontend/src/lib/metadata.ts
+import { locales, pathnames } from "@/config";
+import { siteUrl } from "@/lib/site";
+
+type RouteKey = keyof typeof pathnames;
+
+export function buildAlternates(routeKey: RouteKey, locale: string) {
+    const value = pathnames[routeKey];
+    const pathFor = (l: string) =>
+        typeof value === "string" ? value : value[l as (typeof locales)[number]];
+
+    const languages: Record<string, string> = {};
+    for (const l of locales) {
+        languages[l] = `${siteUrl}${pathFor(l)}`;
+    }
+
+    return {
+        canonical: `${siteUrl}${pathFor(locale)}`,
+        languages,
+    };
+}
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd frontend && npx tsc --noEmit -p tsconfig.json`
+Expected: no errors (this file has no callers yet, but must type-check standalone).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/lib/metadata.ts
+git commit -m "feat: add buildAlternates helper for per-locale canonical/hreflang metadata"
+```
+
+---
+
+### Task 3: Add the `metadata` translation namespace (4 locales)
+
+**Files:**
+- Modify: `frontend/src/messages/es.json`
+- Modify: `frontend/src/messages/en.json`
+- Modify: `frontend/src/messages/fr.json`
+- Modify: `frontend/src/messages/de.json`
+
+Titles are deliberately short — `frontend/src/app/[locale]/layout.tsx` (Task 4) sets a `title.template` of `"%s | LyraTech"`, so Next appends the brand name automatically. Descriptions are full sentences (~140-160 chars), grounded in copy that already exists elsewhere on each page (hero subtitles, `aboutUsIntro.description`, `servicesHome.description`, `footer.description`, etc.) so they read as genuinely different, on-brand summaries instead of invented copy.
+
+- [ ] **Step 1: Insert into `frontend/src/messages/es.json`**
+
+Add as a new top-level key (e.g. right after the closing `}` of `"privacy"`, before the file's final `}`):
+
+```json
+  "metadata": {
+    "home": {
+      "title": "Desarrollo de Software a la Medida",
+      "description": "En LyraTech creamos software a la medida: automatizaciones con IA, proyectos a precio fijo y equipos dedicados. Convertimos tu idea en una solución digital real."
+    },
+    "aboutUs": {
+      "title": "Sobre Nosotros",
+      "description": "Conoce al equipo detrás de LyraTech: mentes brillantes que transforman ideas en soluciones digitales extraordinarias, desde Querétaro, México."
+    },
+    "services": {
+      "title": "Servicios de Desarrollo de Software",
+      "description": "Automatización de procesos, proyectos a precio fijo y equipos dedicados. Tecnología que transforma tu negocio, desde la idea hasta el lanzamiento."
+    },
+    "portfolio": {
+      "title": "Portafolio de Proyectos",
+      "description": "Descubre los proyectos que hemos desarrollado: apps financieras, plataformas de eventos, sitios corporativos y más soluciones digitales exitosas."
+    },
+    "contact": {
+      "title": "Contáctanos",
+      "description": "¿Tienes un proyecto en mente? Escríbenos y hablemos de cómo convertir tu idea en una solución digital real. Respondemos en menos de 24 horas."
+    },
+    "legal": {
+      "title": "Términos y Aviso de Privacidad",
+      "description": "Consulta los Términos y Condiciones y el Aviso de Privacidad de LyraTech para el uso de nuestro sitio web y servicios."
+    }
+  }
+```
+
+- [ ] **Step 2: Insert into `frontend/src/messages/en.json`**
+
+```json
+  "metadata": {
+    "home": {
+      "title": "Custom Software Development",
+      "description": "At LyraTech we build custom software: AI-powered automation, fixed-price projects, and dedicated teams. We turn your idea into a real digital product."
+    },
+    "aboutUs": {
+      "title": "About Us",
+      "description": "Meet the team behind LyraTech: brilliant minds turning ideas into extraordinary digital solutions, from Querétaro, Mexico."
+    },
+    "services": {
+      "title": "Software Development Services",
+      "description": "Process automation, fixed-price projects, and dedicated teams. Technology that transforms your business, from idea to launch."
+    },
+    "portfolio": {
+      "title": "Our Project Portfolio",
+      "description": "Explore the projects we've built: fintech apps, event platforms, corporate websites, and more successful digital solutions."
+    },
+    "contact": {
+      "title": "Contact Us",
+      "description": "Have a project in mind? Reach out and let's talk about turning your idea into a real digital solution. We reply within 24 hours."
+    },
+    "legal": {
+      "title": "Terms & Privacy Policy",
+      "description": "Read LyraTech's Terms and Conditions and Privacy Policy for using our website and services."
+    }
+  }
+```
+
+- [ ] **Step 3: Insert into `frontend/src/messages/fr.json`**
+
+```json
+  "metadata": {
+    "home": {
+      "title": "Développement de Logiciels sur Mesure",
+      "description": "Chez LyraTech, nous créons des logiciels sur mesure : automatisation par IA, projets à prix fixe et équipes dédiées. Nous transformons votre idée en solution numérique réelle."
+    },
+    "aboutUs": {
+      "title": "À Propos",
+      "description": "Découvrez l'équipe derrière LyraTech : des esprits brillants qui transforment des idées en solutions numériques extraordinaires, depuis Querétaro, au Mexique."
+    },
+    "services": {
+      "title": "Services de Développement Logiciel",
+      "description": "Automatisation des processus, projets à prix fixe et équipes dédiées. Une technologie qui transforme votre entreprise, de l'idée au lancement."
+    },
+    "portfolio": {
+      "title": "Portefeuille de Projets",
+      "description": "Découvrez les projets que nous avons réalisés : applications fintech, plateformes d'événements, sites corporatifs et bien d'autres solutions numériques."
+    },
+    "contact": {
+      "title": "Contactez-nous",
+      "description": "Vous avez un projet en tête ? Contactez-nous et parlons de transformer votre idée en solution numérique réelle. Réponse sous 24 heures."
+    },
+    "legal": {
+      "title": "Conditions Générales et Confidentialité",
+      "description": "Consultez les Conditions Générales et la Politique de Confidentialité de LyraTech pour l'utilisation de notre site et de nos services."
+    }
+  }
+```
+
+- [ ] **Step 4: Insert into `frontend/src/messages/de.json`**
+
+```json
+  "metadata": {
+    "home": {
+      "title": "Maßgeschneiderte Softwareentwicklung",
+      "description": "Bei LyraTech entwickeln wir maßgeschneiderte Software: KI-gestützte Automatisierung, Festpreisprojekte und dedizierte Teams. Wir verwandeln Ihre Idee in ein echtes digitales Produkt."
+    },
+    "aboutUs": {
+      "title": "Über Uns",
+      "description": "Lernen Sie das Team hinter LyraTech kennen: brillante Köpfe, die Ideen in außergewöhnliche digitale Lösungen verwandeln, aus Querétaro, Mexiko."
+    },
+    "services": {
+      "title": "Softwareentwicklungsdienste",
+      "description": "Prozessautomatisierung, Festpreisprojekte und dedizierte Teams. Technologie, die Ihr Unternehmen transformiert, von der Idee bis zum Launch."
+    },
+    "portfolio": {
+      "title": "Unser Projektportfolio",
+      "description": "Entdecken Sie die Projekte, die wir realisiert haben: Fintech-Apps, Eventplattformen, Unternehmenswebsites und weitere erfolgreiche digitale Lösungen."
+    },
+    "contact": {
+      "title": "Kontaktieren Sie Uns",
+      "description": "Haben Sie ein Projekt im Kopf? Kontaktieren Sie uns und lassen Sie uns Ihre Idee in eine echte digitale Lösung verwandeln. Antwort innerhalb von 24 Stunden."
+    },
+    "legal": {
+      "title": "AGB und Datenschutz",
+      "description": "Lesen Sie die Allgemeinen Geschäftsbedingungen und die Datenschutzerklärung von LyraTech für die Nutzung unserer Website und Dienste."
+    }
+  }
+```
+
+- [ ] **Step 5: Verify JSON is valid**
+
+Run: `cd frontend && node -e "['es','en','fr','de'].forEach(l => JSON.parse(require('fs').readFileSync('src/messages/'+l+'.json','utf8')))"`
+Expected: no output (no throw) = valid JSON in all 4 files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/messages/es.json frontend/src/messages/en.json frontend/src/messages/fr.json frontend/src/messages/de.json
+git commit -m "feat: add per-page SEO metadata copy in all 4 locales"
+```
+
+---
+
+### Task 4: Site-wide metadata defaults in `[locale]/layout.tsx`
+
+**Files:**
+- Modify: `frontend/src/app/[locale]/layout.tsx`
+
+This sets `metadataBase` (required for Next to resolve absolute URLs correctly), a `title.template` so every page's title automatically gets `| LyraTech` appended, and a locale-aware default (used by any page under `[locale]` that does **not** define its own `generateMetadata` — `/dev`, the personal business-card pages, `/ricardo-v3`, `/ricardo-v4`, `/coming-soon`, the 404 page).
+
+- [ ] **Step 1: Read current imports**
+
+Current top of file:
+```tsx
+import clsx from 'clsx';
+import { setRequestLocale } from 'next-intl/server';
+import { ReactNode } from 'react';
+import { locales } from '@/config';
+import '../globals.css';
+import { NextIntlClientProvider } from 'next-intl';
+import type { Metadata } from 'next';
+import deMessages from '@/messages/de.json';
+import enMessages from '@/messages/en.json';
+import esMessages from '@/messages/es.json';
+import frMessages from '@/messages/fr.json';
+```
+
+Add two imports:
+```tsx
+import { getTranslations } from 'next-intl/server';
+import { siteUrl } from '@/lib/site';
+```
+
+- [ ] **Step 2: Replace `generateMetadata`**
+
+Replace:
+```tsx
+export async function generateMetadata(): Promise<Metadata> {
+    return {
+        title: "Lyra Technologies",
+        description: "Lyra Tech website",
+        icons: [
+            { rel: "icon", url: "/favicon-light.ico", media: "(prefers-color-scheme: light)" },
+            { rel: "icon", url: "/favicon-dark.ico", media: "(prefers-color-scheme: dark)" },
+        ],
+    };
+}
+```
+with:
+```tsx
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { locale } = await params;
+    const t = await getTranslations({ locale, namespace: "metadata.home" });
+
+    return {
+        metadataBase: new URL(siteUrl),
+        title: {
+            template: "%s | LyraTech",
+            default: `${t("title")} | LyraTech`,
+        },
+        description: t("description"),
+        icons: [
+            { rel: "icon", url: "/favicon-light.ico", media: "(prefers-color-scheme: light)" },
+            { rel: "icon", url: "/favicon-dark.ico", media: "(prefers-color-scheme: dark)" },
+        ],
+    };
+}
+```
+
+Note: `Props` (`{ children: ReactNode; params: Promise<{ locale: string }>; }`) is already declared earlier in this file, above `generateStaticParams` and `generateMetadata` — no reordering needed, just reuse it as the type for `generateMetadata`'s argument.
+
+- [ ] **Step 3: Verify**
+
+Run: `cd frontend && npx tsc --noEmit -p tsconfig.json`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/app/[locale]/layout.tsx
+git commit -m "feat: set metadataBase, title template, and locale-aware default metadata"
+```
+
+---
+
+### Task 5: Per-page `generateMetadata` on the 6 marketing pages
+
+**Files:**
+- Modify: `frontend/src/app/[locale]/page.tsx` (home)
+- Modify: `frontend/src/app/[locale]/about-us/page.tsx`
+- Modify: `frontend/src/app/[locale]/services/page.tsx`
+- Modify: `frontend/src/app/[locale]/portfolio/page.tsx`
+- Modify: `frontend/src/app/[locale]/contact/page.tsx`
+- Modify: `frontend/src/app/[locale]/legal/page.tsx`
+
+Same pattern in all six files — add a `generateMetadata` export next to the existing default export. Shown in full for home and about-us; the other four follow identically with their own `routeKey`/namespace substituted (table below).
+
+- [ ] **Step 1: `frontend/src/app/[locale]/page.tsx`**
+
+Add these imports at the top (alongside the existing `React`/component imports):
+```tsx
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "@/lib/metadata";
+```
+
+Add this export (anywhere above or below `export default function Home()`):
+```tsx
+export async function generateMetadata({
+    params,
+}: {
+    params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+    const { locale } = await params;
+    const t = await getTranslations({ locale, namespace: "metadata.home" });
+
+    return {
+        // Home lives in the same route segment as [locale]/layout.tsx, so that
+        // layout's title.template does NOT auto-apply here (confirmed empirically —
+        // it only applies to genuinely nested segments like /about-us). Append the
+        // brand suffix explicitly so home matches every other page's "X | LyraTech".
+        title: `${t("title")} | LyraTech`,
+        description: t("description"),
+        alternates: buildAlternates("/", locale),
+    };
+}
+```
+
+- [ ] **Step 2: `frontend/src/app/[locale]/about-us/page.tsx`**
+
+Same imports. Export:
+```tsx
+export async function generateMetadata({
+    params,
+}: {
+    params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+    const { locale } = await params;
+    const t = await getTranslations({ locale, namespace: "metadata.aboutUs" });
+
+    return {
+        title: t("title"),
+        description: t("description"),
+        alternates: buildAlternates("/about-us", locale),
+    };
+}
+```
+
+- [ ] **Step 3: Repeat for the remaining 4 pages**
+
+Same imports and export shape in each file, substituting the namespace and `buildAlternates` key:
+
+| File | namespace | `buildAlternates` key |
+|---|---|---|
+| `frontend/src/app/[locale]/services/page.tsx` | `metadata.services` | `"/services"` |
+| `frontend/src/app/[locale]/portfolio/page.tsx` | `metadata.portfolio` | `"/portfolio"` |
+| `frontend/src/app/[locale]/contact/page.tsx` | `metadata.contact` | `"/contact"` |
+| `frontend/src/app/[locale]/legal/page.tsx` | `metadata.legal` | `"/legal"` |
+
+Example for `frontend/src/app/[locale]/legal/page.tsx`:
+```tsx
+export async function generateMetadata({
+    params,
+}: {
+    params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+    const { locale } = await params;
+    const t = await getTranslations({ locale, namespace: "metadata.legal" });
+
+    return {
+        title: t("title"),
+        description: t("description"),
+        alternates: buildAlternates("/legal", locale),
+    };
+}
+```
+
+- [ ] **Step 4: Verify types**
+
+Run: `cd frontend && npx tsc --noEmit -p tsconfig.json`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/app/\[locale\]/page.tsx frontend/src/app/\[locale\]/about-us/page.tsx frontend/src/app/\[locale\]/services/page.tsx frontend/src/app/\[locale\]/portfolio/page.tsx frontend/src/app/\[locale\]/contact/page.tsx frontend/src/app/\[locale\]/legal/page.tsx
+git commit -m "feat: add per-page, per-locale title/description/canonical/hreflang metadata"
+```
+
+---
+
+### Task 6: Verify metadata end-to-end
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build**
+
+```bash
+cd frontend
+rm -rf .next
+NEXT_PUBLIC_API_URL=http://localhost:8000 NEXT_PUBLIC_SITE_URL=https://lyratech.com.mx npm run build
+```
+Expected: build succeeds.
+
+- [ ] **Step 2: Spot-check rendered HTML for 3 different pages/locales**
+
+```bash
+timeout 15 npm run start > /tmp/server.log 2>&1 &
+sleep 5
+echo "== / (es) =="
+curl -s http://localhost:3000/ | grep -oE "<title>[^<]*</title>|<meta name=\"description\"[^>]*>|<link rel=\"canonical\"[^>]*>" | head -5
+echo "== /nosotros (es about-us) =="
+curl -s http://localhost:3000/nosotros | grep -oE "<title>[^<]*</title>|<meta name=\"description\"[^>]*>|<link rel=\"canonical\"[^>]*>|<link rel=\"alternate\" hrefLang[^>]*>" | head -10
+echo "== /about-us (en) =="
+curl -s http://localhost:3000/about-us | grep -oE "<title>[^<]*</title>|<meta name=\"description\"[^>]*>" | head -3
+wait
+```
+Expected: `/` and `/nosotros` show **different** `<title>` and `<meta description>` values (this is the exact bug from the user's screenshot — verify it's fixed), `/nosotros` includes a `<link rel="canonical">` pointing at `.../nosotros` and `<link rel="alternate" hreflang="...">` entries for es/en/fr/de.
+
+- [ ] **Step 3: Clean up**
+
+```bash
+rm -f /tmp/server.log
+```
+
+- [ ] **Step 4: No commit** (verification-only task)
+
+---
+
+## Phase 2 — Heading hierarchy fixes
+
+### Task 7: Fix duplicate `<h1>` on Home (`/`) and `/dev`
+
+**Files:**
+- Modify: `frontend/src/components/Home/Portafolio/index.tsx:127`
+- Modify: `frontend/src/components/Home/HelpAndSupport/index.tsx:46`
+
+Both `/` and `/dev` render `HeroHome` (h1, correct — stays), `Home/Portafolio` (currently **also** h1), and `Home/HelpAndSupport` (currently **also** h1). A page must have exactly one `<h1>`; demote the latter two to `<h2>`.
+
+- [ ] **Step 1: `frontend/src/components/Home/Portafolio/index.tsx`**
+
+Replace:
+```tsx
+                <h1 className="uppercase font-extrabold text-2xl md:text-3xl lg:text-4xl xl:text-5xl">
+                    {t("title")}
+                </h1>
+```
+with:
+```tsx
+                <h2 className="uppercase font-extrabold text-2xl md:text-3xl lg:text-4xl xl:text-5xl">
+                    {t("title")}
+                </h2>
+```
+
+- [ ] **Step 2: `frontend/src/components/Home/HelpAndSupport/index.tsx`**
+
+Replace:
+```tsx
+                <h1 className="font-bold text-2xl md:text-3xl lg:text-4xl xl:text-5xl uppercase">
+                    {t("title")}
+                </h1>
+```
+with:
+```tsx
+                <h2 className="font-bold text-2xl md:text-3xl lg:text-4xl xl:text-5xl uppercase">
+                    {t("title")}
+                </h2>
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `cd frontend && npm run build` (or just `npx tsc --noEmit -p tsconfig.json` — JSX tag renames don't affect types, this is a visual/structural check, so also load `http://localhost:3000/` in a browser and confirm the page still looks identical — Tailwind classes are unchanged, only the tag name changed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/Home/Portafolio/index.tsx frontend/src/components/Home/HelpAndSupport/index.tsx
+git commit -m "fix: demote duplicate h1s to h2 on home page (portfolio & help sections)"
+```
+
+---
+
+### Task 8: Fix duplicate `<h1>` on `/legal`
+
+**Files:**
+- Modify: `frontend/src/components/Legal/PrivacyPolicy/index.tsx:24`
+
+`/legal` renders both `TermsAndConditions` (h1 "Términos y Condiciones") and `PrivacyPolicy` (h1 "Aviso de Privacidad") on the same page. Keep Terms as the `h1` (renders first in the DOM) and demote Privacy to `h2`.
+
+- [ ] **Step 1: Replace**
+
+Replace:
+```tsx
+                <motion.h1
+                    initial={{ opacity: 0, y: 20 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.5 }}
+                    viewport={{ once: true }}
+                    className="font-montserrat-bold text-3xl md:text-5xl text-black mb-4"
+                >
+                    {t("title")}
+                </motion.h1>
+```
+with:
+```tsx
+                <motion.h2
+                    initial={{ opacity: 0, y: 20 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.5 }}
+                    viewport={{ once: true }}
+                    className="font-montserrat-bold text-3xl md:text-5xl text-black mb-4"
+                >
+                    {t("title")}
+                </motion.h2>
+```
+
+- [ ] **Step 2: Verify**
+
+Load `http://localhost:3000/legal` after `npm run build && npm run start`, confirm both section titles still render identically (visual, since only the tag changed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/Legal/PrivacyPolicy/index.tsx
+git commit -m "fix: demote Privacy Policy title from h1 to h2 (Terms already uses h1 on /legal)"
+```
+
+---
+
+### Task 9: Add missing `<h2>` on `/portfolio`
+
+**Files:**
+- Modify: `frontend/src/components/Portfolio/PortfolioGrid/index.tsx:126-129`
+- Modify: `frontend/src/messages/es.json`, `en.json`, `fr.json`, `de.json` (new key `portfolioGrid.sectionTitle`)
+
+`/portfolio` currently jumps from the page's one `<h1>` (in `HeroPortfolio`) straight to nine `<h3>` project-name headings inside `PortfolioGrid` — no `<h2>` in between. Add a small section heading above the filter tabs.
+
+- [ ] **Step 1: Add translation key to `frontend/src/messages/es.json`**, inside the existing `"portfolioGrid"` object:
+```json
+    "sectionTitle": "Todos los proyectos",
+```
+(place it as the first key in that object, before `"filterAll"`)
+
+- [ ] **Step 2: Same key in `frontend/src/messages/en.json`**:
+```json
+    "sectionTitle": "All Projects",
+```
+
+- [ ] **Step 3: Same key in `frontend/src/messages/fr.json`**:
+```json
+    "sectionTitle": "Tous les Projets",
+```
+
+- [ ] **Step 4: Same key in `frontend/src/messages/de.json`**:
+```json
+    "sectionTitle": "Alle Projekte",
+```
+
+- [ ] **Step 5: Use it in `frontend/src/components/Portfolio/PortfolioGrid/index.tsx`**
+
+Replace:
+```tsx
+        <section id="portfolio" className="px-6 py-12 md:py-16">
+            <div className="max-w-6xl mx-auto">
+                {/* Filter tabs */}
+                <div className="flex flex-wrap gap-3 mb-10 justify-center">
+```
+with:
+```tsx
+        <section id="portfolio" className="px-6 py-12 md:py-16">
+            <div className="max-w-6xl mx-auto">
+                <h2 className="sr-only">{t("sectionTitle")}</h2>
+
+                {/* Filter tabs */}
+                <div className="flex flex-wrap gap-3 mb-10 justify-center">
+```
+
+Check the top of this component for how `t` is already obtained (it uses `useTranslations("portfolioGrid")` already, since `filterAll` etc. come from that namespace — reuse the same `t`). `sr-only` is a standard Tailwind utility (visually hidden, still readable by search engines/screen readers) — confirm it's available (it's a Tailwind core utility, no config needed) so the visual design doesn't change while the heading gap is fixed.
+
+- [ ] **Step 6: Verify**
+
+Run: `cd frontend && node -e "['es','en','fr','de'].forEach(l => JSON.parse(require('fs').readFileSync('src/messages/'+l+'.json','utf8')))"` then `npx tsc --noEmit -p tsconfig.json`.
+Expected: no errors. Then build + load `/portfolio` in a browser — page should look unchanged (heading is visually hidden).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/Portfolio/PortfolioGrid/index.tsx frontend/src/messages/es.json frontend/src/messages/en.json frontend/src/messages/fr.json frontend/src/messages/de.json
+git commit -m "fix: add missing h2 section heading on /portfolio (was h1 -> h3, skipping a level)"
+```
+
+---
+
+### Task 10 (optional, low priority): De-duplicate flip-card headings on `/services`
+
+**Files:**
+- Modify: `frontend/src/components/Services/ServicesCards/index.tsx:94` and `:121`
+
+`ServicesCards` renders each of the 3 service titles as `<h3>` **twice** — once for the card's front face (line 94-96), once for the back face of a CSS 3D flip (line 121-123). Only one face is visible at a time (the other is `backfaceHidden`-styled), but both exist in the DOM simultaneously, so a screen reader/crawler sees the same heading text twice per card. Not a broken hierarchy (no duplicate `h1`), just redundant headings. The back face also holds a working "volver" (back) button, so this fix keeps the back-face container fully interactive/reachable and only changes the redundant heading itself to a plain paragraph — the front-face `<h3>` (line 94-96, unchanged) remains the one real heading for that service, matching its `<p>` description right below it.
+
+- [ ] **Step 1: Replace the back-face heading**
+
+Replace (`frontend/src/components/Services/ServicesCards/index.tsx:121-123`):
+```tsx
+                                        <h3 className="font-montserrat-bold text-white text-lg leading-tight pr-4">
+                                            {service.title}
+                                        </h3>
+```
+with:
+```tsx
+                                        <p className="font-montserrat-bold text-white text-lg leading-tight pr-4">
+                                            {service.title}
+                                        </p>
+```
+
+- [ ] **Step 2: Verify** — build + load `/services`, click each card to flip it, confirm the back face still looks and behaves identically (only the tag changed, className unchanged).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/Services/ServicesCards/index.tsx
+git commit -m "fix: prevent duplicate h3 announcement on services flip-card back face"
+```
+
+---
+
+### Task 11: Verify heading fixes end-to-end
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build and start**
+
+```bash
+cd frontend
+rm -rf .next
+NEXT_PUBLIC_API_URL=http://localhost:8000 NEXT_PUBLIC_SITE_URL=https://lyratech.com.mx npm run build
+timeout 15 npm run start > /tmp/server.log 2>&1 &
+sleep 5
+```
+
+- [ ] **Step 2: Count `<h1>` per page — every count below must be exactly `1`**
+
+```bash
+for path in "" "nosotros" "servicios" "portafolio" "contacto" "legal"; do
+  count=$(curl -s "http://localhost:3000/$path" | grep -o "<h1" | wc -l)
+  echo "/$path -> $count h1"
+done
+```
+Expected: every line prints `1`.
+
+- [ ] **Step 3: Clean up**
+
+```bash
+rm -f /tmp/server.log
+```
+
+- [ ] **Step 4: No commit** (verification-only task)
+
+---
+
+## Phase 3 — Alt text fixes
+
+### Task 12: Fix generic reused alt text on Home `/` (`Home/AboutUs`)
+
+**Files:**
+- Modify: `frontend/src/components/Home/AboutUs/index.tsx:54`
+
+Two different images (`AboutUs1.png`, `AboutUs2.png`) both currently get the literal, hardcoded `alt="About Us"`. Each card already has a translated `card.title` — use it.
+
+- [ ] **Step 1: Replace**
+
+Replace:
+```tsx
+                                <Image alt="About Us" src={card.img} />
+```
+with:
+```tsx
+                                <Image alt={card.title} src={card.img} />
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd frontend && npx tsc --noEmit -p tsconfig.json`. Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/Home/AboutUs/index.tsx
+git commit -m "fix: use per-card translated title as image alt instead of generic 'About Us'"
+```
+
+---
+
+### Task 13: Translate hardcoded alt text in `AboutUsIntro`
+
+**Files:**
+- Modify: `frontend/src/components/AboutUs/AboutUsIntro/index.tsx`
+- Modify: `frontend/src/messages/es.json`, `en.json`, `fr.json`, `de.json` (new keys `aboutUsIntro.photoTeamAlt`, `aboutUsIntro.photoWorkspaceAlt`)
+
+Every other string in this component comes from `useTranslations("aboutUsIntro")` except the `alts` array (`["Lyratech team", "Lyratech workspace"]`), which is hardcoded English and renders in that language regardless of the visitor's locale.
+
+- [ ] **Step 1: Add keys to `frontend/src/messages/es.json`**, inside the `"aboutUsIntro"` object (anywhere, e.g. after `"description"`):
+```json
+    "photoTeamAlt": "Equipo de Lyratech trabajando",
+    "photoWorkspaceAlt": "Espacio de trabajo de Lyratech",
+```
+
+- [ ] **Step 2: `frontend/src/messages/en.json`**:
+```json
+    "photoTeamAlt": "The Lyratech team at work",
+    "photoWorkspaceAlt": "The Lyratech workspace",
+```
+
+- [ ] **Step 3: `frontend/src/messages/fr.json`**:
+```json
+    "photoTeamAlt": "L'équipe Lyratech au travail",
+    "photoWorkspaceAlt": "L'espace de travail Lyratech",
+```
+
+- [ ] **Step 4: `frontend/src/messages/de.json`**:
+```json
+    "photoTeamAlt": "Das Lyratech-Team bei der Arbeit",
+    "photoWorkspaceAlt": "Der Lyratech-Arbeitsbereich",
+```
+
+- [ ] **Step 5: Update the component**
+
+Replace:
+```tsx
+const images = [Office1, Office2];
+const alts   = ["Lyratech team", "Lyratech workspace"];
+```
+with:
+```tsx
+const images = [Office1, Office2];
+```
+
+Then inside `export default function AboutUsIntro()`, right after `const t = useTranslations("aboutUsIntro");`, add:
+```tsx
+    const alts = [t("photoTeamAlt"), t("photoWorkspaceAlt")];
+```
+
+The existing `alt={alts[idx]}` usage at line ~118 needs no change — `alts` is now translated instead of hardcoded.
+
+- [ ] **Step 6: Verify**
+
+Run: `cd frontend && node -e "['es','en','fr','de'].forEach(l => JSON.parse(require('fs').readFileSync('src/messages/'+l+'.json','utf8')))"` then `npx tsc --noEmit -p tsconfig.json`. Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/AboutUs/AboutUsIntro/index.tsx frontend/src/messages/es.json frontend/src/messages/en.json frontend/src/messages/fr.json frontend/src/messages/de.json
+git commit -m "fix: translate AboutUsIntro image alt text instead of hardcoding English"
+```
+
+---
+
+### Task 14: Fix decorative Navbar notch alt text
+
+**Files:**
+- Modify: `frontend/src/components/Navbar/index.tsx:164-169`
+
+The notch is a clickable UI background graphic, not content — `alt="Lyra Tech Notch"` announces meaningless noise to screen readers on every single page (Navbar is site-wide). It should be `alt=""` so assistive tech skips it; the clickable affordance is already on the wrapping `div[role="button"]` two levels up, which has no accessible label of its own — that's a separate, smaller a11y gap this task does not need to fix (out of scope: it doesn't affect SEO or alt text).
+
+- [ ] **Step 1: Replace**
+
+Replace:
+```tsx
+                <Image
+                    alt="Lyra Tech Notch"
+                    src={ClosedNotch}
+                    className="w-full h-full"
+                    priority
+                />
+```
+with:
+```tsx
+                <Image
+                    alt=""
+                    src={ClosedNotch}
+                    className="w-full h-full"
+                    priority
+                />
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `cd frontend && npx tsc --noEmit -p tsconfig.json`. Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/Navbar/index.tsx
+git commit -m "fix: mark decorative navbar notch image as alt=\"\" instead of mislabeling it"
+```
+
+---
+
+### Task 15: Translate the language-switcher flag alt text
+
+**Files:**
+- Modify: `frontend/src/components/ButtonLanguage/LocaleSwitcher/index.tsx:74`
+- Modify: `frontend/src/messages/es.json`, `en.json`, `fr.json`, `de.json` (new key `buttonLanguage.flagAlt`)
+
+`alt={`${lang.label} Flag`}` — `lang.label` is translated, but the trailing word `"Flag"` is always English.
+
+- [ ] **Step 1: Add key to `frontend/src/messages/es.json`**, inside `"buttonLanguage"`:
+```json
+    "flagAlt": "Bandera de {label}",
+```
+
+- [ ] **Step 2: `frontend/src/messages/en.json`**:
+```json
+    "flagAlt": "{label} flag",
+```
+
+- [ ] **Step 3: `frontend/src/messages/fr.json`**:
+```json
+    "flagAlt": "Drapeau {label}",
+```
+
+- [ ] **Step 4: `frontend/src/messages/de.json`**:
+```json
+    "flagAlt": "{label}-Flagge",
+```
+
+- [ ] **Step 5: Update the component**
+
+Replace:
+```tsx
+                            <Image
+                                src={lang.flag}
+                                alt={`${lang.label} Flag`}
+                                width={20}
+                                height={14}
+                                className="mr-2"
+                            />
+```
+with:
+```tsx
+                            <Image
+                                src={lang.flag}
+                                alt={t("flagAlt", { label: lang.label })}
+                                width={20}
+                                height={14}
+                                className="mr-2"
+                            />
+```
+
+- [ ] **Step 6: Verify**
+
+Run: `cd frontend && node -e "['es','en','fr','de'].forEach(l => JSON.parse(require('fs').readFileSync('src/messages/'+l+'.json','utf8')))"` then `npx tsc --noEmit -p tsconfig.json`. Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/ButtonLanguage/LocaleSwitcher/index.tsx frontend/src/messages/es.json frontend/src/messages/en.json frontend/src/messages/fr.json frontend/src/messages/de.json
+git commit -m "fix: translate language-switcher flag alt text instead of hardcoding 'Flag'"
+```
+
+---
+
+### Task 16: Descriptive, translated photo alt text in `TeamSection` (About Us page)
+
+**Files:**
+- Modify: `frontend/src/components/AboutUs/TeamSection/index.tsx:95`
+- Modify: `frontend/src/messages/es.json`, `en.json`, `fr.json`, `de.json` (new key `teamSection.photoAlt`)
+
+`alt={member.name}` on each team photo is just the bare name with no indication it's a photo — add "Photo of {name}" framing (translated).
+
+- [ ] **Step 1: Add key to `frontend/src/messages/es.json`**, inside `"teamSection"`:
+```json
+    "photoAlt": "Foto de {name}",
+```
+
+- [ ] **Step 2: `frontend/src/messages/en.json`**:
+```json
+    "photoAlt": "Photo of {name}",
+```
+
+- [ ] **Step 3: `frontend/src/messages/fr.json`**:
+```json
+    "photoAlt": "Photo de {name}",
+```
+
+- [ ] **Step 4: `frontend/src/messages/de.json`**:
+```json
+    "photoAlt": "Foto von {name}",
+```
+
+- [ ] **Step 5: Update the component**
+
+Replace:
+```tsx
+                            <Image
+                                src={member.image}
+                                alt={member.name}
+                                width={128}
+                                height={128}
+                                className="w-full h-full object-cover rounded-full"
+                            />
+```
+with:
+```tsx
+                            <Image
+                                src={member.image}
+                                alt={t("photoAlt", { name: member.name })}
+                                width={128}
+                                height={128}
+                                className="w-full h-full object-cover rounded-full"
+                            />
+```
+
+(`t` already exists in this component from `useTranslations("teamSection")`.)
+
+- [ ] **Step 6: Verify**
+
+Run: `cd frontend && node -e "['es','en','fr','de'].forEach(l => JSON.parse(require('fs').readFileSync('src/messages/'+l+'.json','utf8')))"` then `npx tsc --noEmit -p tsconfig.json`. Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/AboutUs/TeamSection/index.tsx frontend/src/messages/es.json frontend/src/messages/en.json frontend/src/messages/fr.json frontend/src/messages/de.json
+git commit -m "fix: add descriptive translated alt text to team member photos"
+```
+
+---
+
+### Task 17: Verify alt-text fixes end-to-end
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build and start**
+
+```bash
+cd frontend
+rm -rf .next
+NEXT_PUBLIC_API_URL=http://localhost:8000 NEXT_PUBLIC_SITE_URL=https://lyratech.com.mx npm run build
+timeout 15 npm run start > /tmp/server.log 2>&1 &
+sleep 5
+```
+
+- [ ] **Step 2: Spot-check**
+
+```bash
+echo "== / should show translated card titles as alt, not 'About Us' twice =="
+curl -s http://localhost:3000/ | grep -oE 'alt="[^"]*"' | sort | uniq -c | sort -rn | head -10
+echo "== /nosotros: navbar notch should be alt=\"\", team photos should say 'Foto de' =="
+curl -s http://localhost:3000/nosotros | grep -oE 'alt="[^"]*"' | head -20
+```
+Expected: no `alt="About Us"` duplicate, no `alt="Lyra Tech Notch"`, team photo alts read `"Foto de <name>"` (es).
+
+- [ ] **Step 3: Clean up**
+
+```bash
+rm -f /tmp/server.log
+```
+
+- [ ] **Step 4: No commit** (verification-only task)
+
+---
+
+## Phase 4 (optional — pages already blocked from indexing via `robots.txt`)
+
+These fixes are accessibility-only (screen readers), not SEO, because `frontend/src/app/robots.ts` already disallows `/ricardo`, `/ricardo-v3`, `/ricardo-v4`, `/ezzat`, `/daniel-contreras`, `/daniel-queijeiro`, `/galo`, `/business-card`. Confirm with the user before spending time here — do Phases 1-3 first regardless.
+
+### Task 18: Promote person-name `<p>` to `<h1>` on business-card pages
+
+**Files:**
+- Modify: `frontend/src/components/DigitalBusinessCardV2/Profile/index.tsx:64-71` (used by `/ricardo`, `/ezzat`, `/galo`, `/maxime`, `/daniel-contreras`, `/daniel-queijeiro`)
+- Modify: `frontend/src/components/DigitalBusinessCard/Profile/index.tsx:40` (used by `/business-card`)
+- Modify: `frontend/src/components/DigitalBusinessCardV3/Hero/index.tsx:154` (used by `/ricardo-v3`)
+- Modify: `frontend/src/app/[locale]/ricardo-v4/page.tsx:17`
+
+All four currently render the person's name as `<p>`/`<motion.p>` with zero `<h1>` anywhere on the page. Swap the tag only (keep the same `className` so nothing changes visually — Tailwind's preflight reset removes default heading margins).
+
+- [ ] **Step 1: `frontend/src/components/DigitalBusinessCardV2/Profile/index.tsx`**
+
+Replace:
+```tsx
+            <motion.p
+                initial={{ opacity: 0, y: 16 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5, delay: 0.25, ease: "easeOut" }}
+                className="text-xl md:text-2xl lg:text-3xl mt-3 md:mt-5 font-zendots text-white text-center leading-snug"
+            >
+                {name}
+            </motion.p>
+```
+with:
+```tsx
+            <motion.h1
+                initial={{ opacity: 0, y: 16 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5, delay: 0.25, ease: "easeOut" }}
+                className="text-xl md:text-2xl lg:text-3xl mt-3 md:mt-5 font-zendots text-white text-center leading-snug"
+            >
+                {name}
+            </motion.h1>
+```
+
+- [ ] **Step 2: `frontend/src/components/DigitalBusinessCard/Profile/index.tsx`**
+
+Replace:
+```tsx
+            <p className="text-3xl mt-4 font-zendots mx-5 text-center">{name}</p>
+```
+with:
+```tsx
+            <h1 className="text-3xl mt-4 font-zendots mx-5 text-center">{name}</h1>
+```
+
+- [ ] **Step 3: `frontend/src/components/DigitalBusinessCardV3/Hero/index.tsx`**
+
+Replace:
+```tsx
+                        <p className="text-sm font-bold text-[#272a33] leading-none font-montserrat-bold">{name}</p>
+```
+with:
+```tsx
+                        <h1 className="text-sm font-bold text-[#272a33] leading-none font-montserrat-bold">{name}</h1>
+```
+
+- [ ] **Step 4: `frontend/src/app/[locale]/ricardo-v4/page.tsx`**
+
+Replace:
+```tsx
+                        <p className="text-sm font-bold text-[#272a33] leading-none font-montserrat-bold">Ricardo Sierra Roa</p>
+```
+with:
+```tsx
+                        <h1 className="text-sm font-bold text-[#272a33] leading-none font-montserrat-bold">Ricardo Sierra Roa</h1>
+```
+
+- [ ] **Step 5: Verify**
+
+Build + load `/ricardo`, `/business-card`, `/ricardo-v3`, `/ricardo-v4` in a browser. Confirm no visual change (only the tag changed, className identical).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/DigitalBusinessCardV2/Profile/index.tsx frontend/src/components/DigitalBusinessCard/Profile/index.tsx frontend/src/components/DigitalBusinessCardV3/Hero/index.tsx "frontend/src/app/[locale]/ricardo-v4/page.tsx"
+git commit -m "fix: promote person name to h1 on digital business card pages (were 0 headings)"
+```
+
+---
+
+### Task 19: Translated photo alt text on business-card pages
+
+**Files:**
+- Modify: `frontend/src/components/DigitalBusinessCardV2/Profile/index.tsx` (import `useTranslations`, add call)
+- Modify: `frontend/src/components/DigitalBusinessCard/Profile/index.tsx` (re-enable the already-commented `useTranslations` import)
+- Modify: `frontend/src/components/DigitalBusinessCardV3/Hero/index.tsx` (import `useTranslations`, add call)
+- Modify: `frontend/src/messages/es.json`, `en.json`, `fr.json`, `de.json` (new namespace `businessCard`)
+
+- [ ] **Step 1: Add namespace to `frontend/src/messages/es.json`** (new top-level key):
+```json
+  "businessCard": {
+    "photoAlt": "Foto de {name}"
+  },
+```
+
+- [ ] **Step 2: `frontend/src/messages/en.json`**:
+```json
+  "businessCard": {
+    "photoAlt": "Photo of {name}"
+  },
+```
+
+- [ ] **Step 3: `frontend/src/messages/fr.json`**:
+```json
+  "businessCard": {
+    "photoAlt": "Photo de {name}"
+  },
+```
+
+- [ ] **Step 4: `frontend/src/messages/de.json`**:
+```json
+  "businessCard": {
+    "photoAlt": "Foto von {name}"
+  },
+```
+
+- [ ] **Step 5: `frontend/src/components/DigitalBusinessCardV2/Profile/index.tsx`**
+
+Add import:
+```tsx
+import { useTranslations } from "next-intl";
+```
+Inside `function Profile({ imageSrc, name, position }: Readonly<ProfileProps>) {`, add as the first line of the function body:
+```tsx
+    const t = useTranslations("businessCard");
+```
+Replace:
+```tsx
+                        <Image
+                            src={imageSrc}
+                            alt={name}
+                            width={160}
+                            height={160}
+                            className="w-28 h-28 md:w-36 md:h-36 lg:w-40 lg:h-40 rounded-full object-cover"
+                            priority
+                        />
+```
+with:
+```tsx
+                        <Image
+                            src={imageSrc}
+                            alt={t("photoAlt", { name })}
+                            width={160}
+                            height={160}
+                            className="w-28 h-28 md:w-36 md:h-36 lg:w-40 lg:h-40 rounded-full object-cover"
+                            priority
+                        />
+```
+
+- [ ] **Step 6: `frontend/src/components/DigitalBusinessCard/Profile/index.tsx`**
+
+Replace:
+```tsx
+//import { useTranslations } from "next-intl";
+```
+with:
+```tsx
+import { useTranslations } from "next-intl";
+```
+Replace:
+```tsx
+function Profile({ imageSrc, name, position }: ProfileProps) {
+    //const t = useTranslations("profileCard");
+```
+with:
+```tsx
+function Profile({ imageSrc, name, position }: ProfileProps) {
+    const t = useTranslations("businessCard");
+```
+Replace:
+```tsx
+                    <Image
+                        src={imageSrc}
+                        alt={name}
+                        width={240}
+                        height={240}
+                        className="w-40 h-40 rounded-full"
+                        priority
+                    />
+```
+with:
+```tsx
+                    <Image
+                        src={imageSrc}
+                        alt={t("photoAlt", { name })}
+                        width={240}
+                        height={240}
+                        className="w-40 h-40 rounded-full"
+                        priority
+                    />
+```
+
+- [ ] **Step 7: `frontend/src/components/DigitalBusinessCardV3/Hero/index.tsx`**
+
+Add import:
+```tsx
+import { useTranslations } from "next-intl";
+```
+Inside `export default function Hero({ name, role, company, phone, email }: HeroProps) {`, add as the first line of the function body:
+```tsx
+    const t = useTranslations("businessCard");
+```
+Replace:
+```tsx
+                    <Image src={RichieBase} alt={name} priority />
+```
+with:
+```tsx
+                    <Image src={RichieBase} alt={t("photoAlt", { name })} priority />
+```
+
+- [ ] **Step 8: Verify**
+
+Run: `cd frontend && node -e "['es','en','fr','de'].forEach(l => JSON.parse(require('fs').readFileSync('src/messages/'+l+'.json','utf8')))"` then `npx tsc --noEmit -p tsconfig.json`. Expected: no errors. Then build + load `/ricardo`, `/business-card`, `/ricardo-v3`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/components/DigitalBusinessCardV2/Profile/index.tsx frontend/src/components/DigitalBusinessCard/Profile/index.tsx frontend/src/components/DigitalBusinessCardV3/Hero/index.tsx frontend/src/messages/es.json frontend/src/messages/en.json frontend/src/messages/fr.json frontend/src/messages/de.json
+git commit -m "fix: translated descriptive alt text for business-card profile photos"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** metadata (Phase 1) ✓, headings (Phase 2, includes the 3 concrete structural bugs found: home/dev duplicate h1, legal duplicate h1, portfolio h1→h3 skip) ✓, alt text (Phase 3, all 5 issues from the audit) ✓, multilingual requirement ✓ (every new string is added to all 4 `messages/*.json` files). Business-card pages (Phase 4) explicitly deprioritized with reasoning, not silently dropped.
+- **Not included by design:** Open Graph / Twitter card images (no existing OG asset in the repo to point to — would need new design assets, out of scope for this pass; flag to the user separately if wanted), and the minor Services flip-card duplicate-h3 issue is marked optional (Task 10) since it doesn't change page indexing.
+- **Verification approach:** every phase ends with a build + `curl`/`grep` check against real rendered HTML, matching how the sitemap/robots/404 work was verified earlier in this session (no test framework exists in this repo to write unit tests against).

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -66,6 +66,33 @@ const nextConfig: NextConfig = {
     },
     reactStrictMode: true,
 
+    async redirects() {
+        return [
+            // The placeholder "coming soon" landing page is gone now that the
+            // real site is live — send any old links/bookmarks/search results home.
+            {
+                source: "/coming-soon",
+                destination: "/",
+                permanent: true,
+            },
+            {
+                source: "/proximamente",
+                destination: "/",
+                permanent: true,
+            },
+            {
+                source: "/demnaechst",
+                destination: "/",
+                permanent: true,
+            },
+            {
+                source: "/bientot-disponible",
+                destination: "/",
+                permanent: true,
+            },
+        ];
+    },
+
     async rewrites() {
         return [
             // ==================

--- a/frontend/src/app/[locale]/[...rest]/page.tsx
+++ b/frontend/src/app/[locale]/[...rest]/page.tsx
@@ -1,0 +1,7 @@
+import { notFound } from "next/navigation";
+
+// Any URL that doesn't match a known page lands here. Without this catch-all,
+// Next serves its generic built-in 404 instead of app/[locale]/not-found.tsx.
+export default function CatchAllPage() {
+    notFound();
+}

--- a/frontend/src/app/[locale]/about-us/page.tsx
+++ b/frontend/src/app/[locale]/about-us/page.tsx
@@ -1,4 +1,7 @@
 import React from "react";
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "@/lib/metadata";
 import Navbar from "@/components/Navbar/index";
 import HeroAboutUs from "@/components/AboutUs/HeroAboutUs";
 import AboutUsIntro from "@/components/AboutUs/AboutUsIntro";
@@ -7,6 +10,21 @@ import VisionMission from "@/components/AboutUs/VisionMission";
 import ButtonLanguage from "@/components/ButtonLanguage";
 import DiagnosticGoFloatingButton from "@/components/Services/DiagnosticGo/FloatingButton";
 import Footer from "@/components/Footer";
+
+export async function generateMetadata({
+    params,
+}: {
+    params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+    const { locale } = await params;
+    const t = await getTranslations({ locale, namespace: "metadata.aboutUs" });
+
+    return {
+        title: t("title"),
+        description: t("description"),
+        alternates: buildAlternates("/about-us", locale),
+    };
+}
 
 export default function AboutUsPage() {
     return (

--- a/frontend/src/app/[locale]/contact/page.tsx
+++ b/frontend/src/app/[locale]/contact/page.tsx
@@ -1,4 +1,7 @@
 import React from "react";
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "@/lib/metadata";
 import Navbar from "@/components/Navbar/index";
 import HeroContact from "@/components/Contact/HeroContact";
 import ContactForm from "@/components/Contact/ContactForm";
@@ -6,6 +9,21 @@ import FAQ from "@/components/Contact/FAQ";
 import ButtonLanguage from "@/components/ButtonLanguage";
 import DiagnosticGoFloatingButton from "@/components/Services/DiagnosticGo/FloatingButton";
 import Footer from "@/components/Footer";
+
+export async function generateMetadata({
+    params,
+}: {
+    params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+    const { locale } = await params;
+    const t = await getTranslations({ locale, namespace: "metadata.contact" });
+
+    return {
+        title: t("title"),
+        description: t("description"),
+        alternates: buildAlternates("/contact", locale),
+    };
+}
 
 export default function ContactPage() {
     return (

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -1,10 +1,11 @@
 import clsx from 'clsx';
-import { setRequestLocale } from 'next-intl/server';
+import { setRequestLocale, getTranslations } from 'next-intl/server';
 import { ReactNode } from 'react';
 import { locales } from '@/config';
 import '../globals.css';
 import { NextIntlClientProvider } from 'next-intl';
 import type { Metadata } from 'next';
+import { siteUrl } from '@/lib/site';
 import deMessages from '@/messages/de.json';
 import enMessages from '@/messages/en.json';
 import esMessages from '@/messages/es.json';
@@ -28,10 +29,17 @@ export function generateStaticParams() {
 
 export const dynamic = 'force-dynamic';
 
-export async function generateMetadata(): Promise<Metadata> {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { locale } = await params;
+    const t = await getTranslations({ locale, namespace: "metadata.home" });
+
     return {
-        title: "Lyra Technologies",
-        description: "Lyra Tech website",
+        metadataBase: new URL(siteUrl),
+        title: {
+            template: "%s | LyraTech",
+            default: `${t("title")} | LyraTech`,
+        },
+        description: t("description"),
         icons: [
             { rel: "icon", url: "/favicon-light.ico", media: "(prefers-color-scheme: light)" },
             { rel: "icon", url: "/favicon-dark.ico", media: "(prefers-color-scheme: dark)" },

--- a/frontend/src/app/[locale]/legal/page.tsx
+++ b/frontend/src/app/[locale]/legal/page.tsx
@@ -1,10 +1,28 @@
 import React from "react";
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "@/lib/metadata";
 import Navbar from "@/components/Navbar/index";
 import ButtonLanguage from "@/components/ButtonLanguage";
 import DiagnosticGoFloatingButton from "@/components/Services/DiagnosticGo/FloatingButton";
 import TermsAndConditions from "@/components/Legal/TermsAndConditions";
 import PrivacyPolicy from "@/components/Legal/PrivacyPolicy";
 import Footer from "@/components/Footer";
+
+export async function generateMetadata({
+    params,
+}: {
+    params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+    const { locale } = await params;
+    const t = await getTranslations({ locale, namespace: "metadata.legal" });
+
+    return {
+        title: t("title"),
+        description: t("description"),
+        alternates: buildAlternates("/legal", locale),
+    };
+}
 
 export default function LegalPage() {
     return (

--- a/frontend/src/app/[locale]/not-found.tsx
+++ b/frontend/src/app/[locale]/not-found.tsx
@@ -1,0 +1,13 @@
+import Navbar from "@/components/Navbar/index";
+import Footer from "@/components/Footer";
+import NotFound from "@/components/NotFound";
+
+export default function NotFoundPage() {
+    return (
+        <div>
+            <Navbar />
+            <NotFound />
+            <Footer />
+        </div>
+    );
+}

--- a/frontend/src/app/[locale]/page.tsx
+++ b/frontend/src/app/[locale]/page.tsx
@@ -1,4 +1,7 @@
 import React from "react";
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "@/lib/metadata";
 import Navbar from "@/components/Navbar/index";
 import Hero from "@/components/Home/HeroHome";
 import AboutUs from "@/components/Home/AboutUs";
@@ -8,6 +11,25 @@ import HelpAndSupport from "@/components/Home/HelpAndSupport";
 import ButtonLanguage from "@/components/ButtonLanguage";
 import DiagnosticGoFloatingButton from "@/components/Services/DiagnosticGo/FloatingButton";
 import Footer from "@/components/Footer";
+
+export async function generateMetadata({
+    params,
+}: {
+    params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+    const { locale } = await params;
+    const t = await getTranslations({ locale, namespace: "metadata.home" });
+
+    return {
+        // Home lives in the same route segment as [locale]/layout.tsx, so
+        // that layout's title.template does not auto-apply here (it only
+        // applies to genuinely nested segments) — append the brand suffix
+        // explicitly to stay consistent with every other page's "X | LyraTech".
+        title: `${t("title")} | LyraTech`,
+        description: t("description"),
+        alternates: buildAlternates("/", locale),
+    };
+}
 
 export default function Home() {
     return (

--- a/frontend/src/app/[locale]/portfolio/page.tsx
+++ b/frontend/src/app/[locale]/portfolio/page.tsx
@@ -1,10 +1,28 @@
 import React from "react";
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "@/lib/metadata";
 import Navbar from "@/components/Navbar/index";
 import HeroPortfolio from "@/components/Portfolio/HeroPortfolio";
 import PortfolioGrid from "@/components/Portfolio/PortfolioGrid";
 import ButtonLanguage from "@/components/ButtonLanguage";
 import DiagnosticGoFloatingButton from "@/components/Services/DiagnosticGo/FloatingButton";
 import Footer from "@/components/Footer";
+
+export async function generateMetadata({
+    params,
+}: {
+    params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+    const { locale } = await params;
+    const t = await getTranslations({ locale, namespace: "metadata.portfolio" });
+
+    return {
+        title: t("title"),
+        description: t("description"),
+        alternates: buildAlternates("/portfolio", locale),
+    };
+}
 
 export default function PortfolioPage() {
     return (

--- a/frontend/src/app/[locale]/services/page.tsx
+++ b/frontend/src/app/[locale]/services/page.tsx
@@ -1,4 +1,7 @@
 import React from "react";
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { buildAlternates } from "@/lib/metadata";
 import Navbar from "@/components/Navbar/index";
 import HeroServices from "@/components/Services/HeroServices";
 import DiagnosticoStrategico from "@/components/Services/DiagnosticoStrategico";
@@ -6,6 +9,21 @@ import ServicesCards from "@/components/Services/ServicesCards";
 import ButtonLanguage from "@/components/ButtonLanguage";
 import DiagnosticGoFloatingButton from "@/components/Services/DiagnosticGo/FloatingButton";
 import Footer from "@/components/Footer";
+
+export async function generateMetadata({
+    params,
+}: {
+    params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+    const { locale } = await params;
+    const t = await getTranslations({ locale, namespace: "metadata.services" });
+
+    return {
+        title: t("title"),
+        description: t("description"),
+        alternates: buildAlternates("/services", locale),
+    };
+}
 
 export default function ServicesPage() {
     return (

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,13 +1,10 @@
 import type { MetadataRoute } from "next";
-
-const productionUrl = "https://lyratech.com.mx";
-const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || productionUrl).replace(/\/$/, "");
-const isProduction = siteUrl === productionUrl;
+import { siteUrl, isProductionSite } from "@/lib/site";
 
 export default function robots(): MetadataRoute.Robots {
     // Dev/staging deploys share this same code but must never be indexed —
     // otherwise Google ends up with duplicate content next to production.
-    if (!isProduction) {
+    if (!isProductionSite) {
         return {
             rules: {
                 userAgent: "*",

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -11,7 +11,6 @@ const publicRouteKeys = [
     "/services",
     "/portfolio",
     "/contact",
-    "/coming-soon",
     "/legal",
 ] as const;
 

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,7 +1,6 @@
 import type { MetadataRoute } from "next";
 import { pathnames } from "@/config";
-
-const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || "https://lyratech.com.mx").replace(/\/$/, "");
+import { siteUrl } from "@/lib/site";
 
 // Only the marketing pages meant for organic search. Personal business-card
 // profiles, /dev, and the admin dashboard are intentionally left out.

--- a/frontend/src/components/AboutUs/AboutUsIntro/index.tsx
+++ b/frontend/src/components/AboutUs/AboutUsIntro/index.tsx
@@ -17,10 +17,10 @@ const features = [
 ] as const;
 
 const images = [Office1, Office2];
-const alts   = ["Lyratech team", "Lyratech workspace"];
 
 export default function AboutUsIntro() {
     const t = useTranslations("aboutUsIntro");
+    const alts = [t("photoTeamAlt"), t("photoWorkspaceAlt")];
     const [front, setFront] = useState(0);
 
     return (

--- a/frontend/src/components/AboutUs/TeamSection/index.tsx
+++ b/frontend/src/components/AboutUs/TeamSection/index.tsx
@@ -92,7 +92,7 @@ export default function TeamSection() {
                         <div className="w-32 h-32 rounded-full bg-white flex items-center justify-center mb-5 overflow-hidden ring-4 ring-lyratech-light-purple">
                             <Image
                                 src={member.image}
-                                alt={member.name}
+                                alt={t("photoAlt", { name: member.name })}
                                 width={128}
                                 height={128}
                                 className="w-full h-full object-cover rounded-full"

--- a/frontend/src/components/ButtonLanguage/LocaleSwitcher/index.tsx
+++ b/frontend/src/components/ButtonLanguage/LocaleSwitcher/index.tsx
@@ -71,7 +71,7 @@ export default function LocaleSwitcher({ closeModalAction, currentLocale }: Read
                         >
                             <Image
                                 src={lang.flag}
-                                alt={`${lang.label} Flag`}
+                                alt={t("flagAlt", { label: lang.label })}
                                 width={20}
                                 height={14}
                                 className="mr-2"

--- a/frontend/src/components/Home/AboutUs/index.tsx
+++ b/frontend/src/components/Home/AboutUs/index.tsx
@@ -51,7 +51,7 @@ export default function ScrollStack() {
                                 </div>
                             </div>
                             <div className="mt-14 md:mt-6 lg:w-1/2">
-                                <Image alt="About Us" src={card.img} />
+                                <Image alt={card.title} src={card.img} />
                             </div>
                         </div>
                     </motion.div>

--- a/frontend/src/components/Home/HelpAndSupport/index.tsx
+++ b/frontend/src/components/Home/HelpAndSupport/index.tsx
@@ -43,9 +43,9 @@ function HelpAndSupport() {
         <div id="contact" className="text-black font-montserrat mb-14 md:mb-32">
             {/*Title*/}
             <div className="flex flex-col text-center mx-6 py-8 gap-y-6 rounded-[30px] shadow-contact md:mx-16 md:py-12 lg:mx-20 lg:gap-y-10 xl:mx-28 xl:py-16 xl:gap-y-14">
-                <h1 className="font-bold text-2xl md:text-3xl lg:text-4xl xl:text-5xl uppercase">
+                <h2 className="font-bold text-2xl md:text-3xl lg:text-4xl xl:text-5xl uppercase">
                     {t("title")}
-                </h1>
+                </h2>
                 <p className="px-4 md:px-14 md:text-lg lg:px-20 lg:text-xl xl:px-64">
                     {t("subtitle")}
                 </p>

--- a/frontend/src/components/Home/Portafolio/index.tsx
+++ b/frontend/src/components/Home/Portafolio/index.tsx
@@ -124,9 +124,9 @@ function Portafolio() {
         <div id="portfolio" className="font-montserrat mb-32 md:mb-40 lg:mb-52">
             {/* Title + Description */}
             <div className="text-center px-10 md:px-16 lg:px-20 xl:px-28">
-                <h1 className="uppercase font-extrabold text-2xl md:text-3xl lg:text-4xl xl:text-5xl">
+                <h2 className="uppercase font-extrabold text-2xl md:text-3xl lg:text-4xl xl:text-5xl">
                     {t("title")}
-                </h1>
+                </h2>
                 <p className="mt-5 md:text-lg md:mt-8 lg:text-xl">
                     {t("description")}
                 </p>

--- a/frontend/src/components/Legal/PrivacyPolicy/index.tsx
+++ b/frontend/src/components/Legal/PrivacyPolicy/index.tsx
@@ -21,7 +21,7 @@ export default function PrivacyPolicy() {
     return (
         <section id="privacidad" className="py-20 px-6 bg-gray-50 scroll-mt-24">
             <div className="max-w-3xl mx-auto">
-                <motion.h1
+                <motion.h2
                     initial={{ opacity: 0, y: 20 }}
                     whileInView={{ opacity: 1, y: 0 }}
                     transition={{ duration: 0.5 }}
@@ -29,7 +29,7 @@ export default function PrivacyPolicy() {
                     className="font-montserrat-bold text-3xl md:text-5xl text-black mb-4"
                 >
                     {t("title")}
-                </motion.h1>
+                </motion.h2>
 
                 <p className="font-montserrat text-gray-400 text-sm mb-12">
                     {t("lastUpdated")}

--- a/frontend/src/components/Navbar/index.tsx
+++ b/frontend/src/components/Navbar/index.tsx
@@ -162,7 +162,7 @@ function Navbar() {
                 `}
             >
                 <Image
-                    alt="Lyra Tech Notch"
+                    alt=""
                     src={ClosedNotch}
                     className="w-full h-full"
                     priority

--- a/frontend/src/components/NotFound/index.tsx
+++ b/frontend/src/components/NotFound/index.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import React from "react";
+import { motion } from "framer-motion";
+import { useTranslations } from "next-intl";
+import { HiOutlineExclamationCircle } from "react-icons/hi";
+import { Link } from "@/navigation";
+
+export default function NotFound() {
+    const t = useTranslations("notFound");
+
+    return (
+        <section className="relative min-h-[80vh] flex flex-col items-center justify-center px-6 overflow-hidden text-center">
+            <div className="absolute top-1/3 -left-20 w-80 h-80 bg-lyratech-light-purple rounded-full blur-3xl opacity-30 -z-10" />
+            <div className="absolute bottom-1/4 -right-20 w-96 h-96 bg-lyratech-purple rounded-full blur-3xl opacity-10 -z-10" />
+
+            <motion.div
+                initial={{ opacity: 0, y: -20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5 }}
+                className="flex items-center gap-2 sm:gap-3 bg-white border border-gray-200 rounded-full px-6 py-3 sm:px-10 sm:py-4 shadow-sm mb-8 sm:mb-10"
+            >
+                <HiOutlineExclamationCircle className="text-lyratech-purple text-2xl sm:text-3xl" />
+                <span className="font-montserrat text-gray-700 font-semibold text-base sm:text-lg">
+                    {t("badge")}
+                </span>
+            </motion.div>
+
+            <motion.h1
+                initial={{ opacity: 0, y: 30 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.1 }}
+                className="font-montserrat-bold text-6xl sm:text-7xl md:text-8xl leading-tight mb-6 text-lyratech-purple"
+            >
+                404
+            </motion.h1>
+
+            <motion.p
+                initial={{ opacity: 0, y: 30 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.2 }}
+                className="font-montserrat text-gray-500 text-sm sm:text-base md:text-lg max-w-xl mx-auto leading-relaxed mb-10 px-2 sm:px-0"
+            >
+                {t("description")}
+            </motion.p>
+
+            <motion.div
+                initial={{ opacity: 0, y: 30 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6, delay: 0.3 }}
+            >
+                <Link
+                    href="/"
+                    className="inline-block px-8 py-3 rounded-full text-sm font-bold uppercase tracking-wider text-white bg-gradient-to-r from-lyratech-purple to-lyratech-blue hover:opacity-90 transition-all duration-300 shadow-lg"
+                >
+                    {t("button")}
+                </Link>
+            </motion.div>
+        </section>
+    );
+}

--- a/frontend/src/components/Portfolio/PortfolioGrid/index.tsx
+++ b/frontend/src/components/Portfolio/PortfolioGrid/index.tsx
@@ -125,6 +125,8 @@ export default function PortfolioGrid() {
     return (
         <section id="portfolio" className="px-6 py-12 md:py-16">
             <div className="max-w-6xl mx-auto">
+                <h2 className="sr-only">{tGrid("sectionTitle")}</h2>
+
                 {/* Filter tabs */}
                 <div className="flex flex-wrap gap-3 mb-10 justify-center">
                     {filters.map((f) => (

--- a/frontend/src/components/Services/ServicesCards/index.tsx
+++ b/frontend/src/components/Services/ServicesCards/index.tsx
@@ -118,9 +118,9 @@ export default function ServicesCards() {
                                         }}
                                     >
                                         <div className="flex items-center justify-between mb-6">
-                                            <h3 className="font-montserrat-bold text-white text-lg leading-tight pr-4">
+                                            <p className="font-montserrat-bold text-white text-lg leading-tight pr-4">
                                                 {service.title}
-                                            </h3>
+                                            </p>
                                             <button
                                                 onClick={() => setFlipped(null)}
                                                 className="text-gray-400 hover:text-white transition-colors flex-shrink-0"

--- a/frontend/src/lib/metadata.ts
+++ b/frontend/src/lib/metadata.ts
@@ -1,0 +1,20 @@
+import { locales, pathnames } from "@/config";
+import { siteUrl } from "@/lib/site";
+
+type RouteKey = keyof typeof pathnames;
+
+export function buildAlternates(routeKey: RouteKey, locale: string) {
+    const value = pathnames[routeKey];
+    const pathFor = (l: string) =>
+        typeof value === "string" ? value : value[l as (typeof locales)[number]];
+
+    const languages: Record<string, string> = {};
+    for (const l of locales) {
+        languages[l] = `${siteUrl}${pathFor(l)}`;
+    }
+
+    return {
+        canonical: `${siteUrl}${pathFor(locale)}`,
+        languages,
+    };
+}

--- a/frontend/src/lib/site.ts
+++ b/frontend/src/lib/site.ts
@@ -1,0 +1,4 @@
+const productionSiteUrl = "https://lyratech.com.mx";
+
+export const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || productionSiteUrl).replace(/\/$/, "");
+export const isProductionSite = siteUrl === productionSiteUrl;

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -360,6 +360,11 @@
     "resources4": "Rechtliches",
     "copyright": "© {year} LyraTech. Alle Rechte vorbehalten."
   },
+  "notFound": {
+    "badge": "Seite nicht gefunden",
+    "description": "Entschuldigung, wir konnten die gesuchte Seite nicht finden. Der Link ist möglicherweise fehlerhaft oder die Seite wurde verschoben.",
+    "button": "Zurück zur Startseite"
+  },
   "terms": {
     "title": "Allgemeine Geschäftsbedingungen",
     "lastUpdated": "Zuletzt aktualisiert: Juli 2026",

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -55,6 +55,7 @@
     "locale": "{locale, select, es {🇪🇸 Español} en {🇬🇧 English} de {🇩🇪 Deutsch} fr {🇫🇷 Français} other {Unknown}}"
   },
   "buttonLanguage": {
+    "flagAlt": "{label}-Flagge",
     "Spanish": "Spanisch",
     "English": "Englisch",
     "German": "Deutsch",
@@ -105,6 +106,8 @@
     "titlePurple": "Ideen",
     "titleBlack2": "in digitale Realitäten",
     "description": "Bei LyraTech schreiben wir nicht nur Code, wir schaffen Erlebnisse, die verbinden, inspirieren und echten Mehrwert erzeugen. Wir sind ein leidenschaftliches multidisziplinäres Team.",
+    "photoTeamAlt": "Das Lyratech-Team bei der Arbeit",
+    "photoWorkspaceAlt": "Der Lyratech-Arbeitsbereich",
     "feat1Title": "Leidenschaft",
     "feat1Desc": "Wir lieben was wir tun und das sieht man in jeder Zeile Code",
     "feat2Title": "Präzision",
@@ -122,6 +125,7 @@
   },
   "teamSection": {
     "title": "Unser Team",
+    "photoAlt": "Foto von {name}",
     "desc1": "Visionärer Stratege, der Ideen in digitale Produkte mit hoher Wirkung verwandelt.",
     "desc2": "Koordiniert Prozesse und Teams, damit jedes Projekt pünktlich und mit Exzellenz geliefert wird.",
     "desc3": "Architekt robuster, skalierbarer und hochmoderner Technologielösungen.",
@@ -194,6 +198,7 @@
     "verMas": "Mehr lesen"
   },
   "portfolioGrid": {
+    "sectionTitle": "Alle Projekte",
     "filterAll": "Alle",
     "filterWeb": "Web",
     "filterMobile": "Mobil",
@@ -396,5 +401,31 @@
     "section5Body": "Wir speichern Ihre Daten nur so lange, wie es für den Zweck erforderlich ist, für den sie erhoben wurden, oder bis Sie deren Löschung beantragen. Wir wenden angemessene technische und organisatorische Maßnahmen an, um Ihre Daten vor unbefugtem Zugriff, Verlust oder Missbrauch zu schützen. Wir geben Ihre Daten nicht zu kommerziellen Zwecken an Dritte weiter und verkaufen sie nicht; wir nutzen jedoch externe Dienstleister, die Daten in unserem Auftrag verarbeiten, um den Dienst bereitzustellen: OpenRouter (zur Erstellung der KI-Analyse der Diagnose) und Resend (zum Versand von E-Mails), jeweils gemäß ihren eigenen Datenschutzrichtlinien. Diese Übermittlungen sind für die Erbringung der von Ihnen angeforderten Dienstleistung erforderlich.",
     "section6Title": "6. Einsatz künstlicher Intelligenz bei der Diagnose",
     "section6Body": "Um Ihre strategische Diagnose zu erstellen, sendet Diagnostic Go die von Ihnen geteilten Antworten an ein Modell künstlicher Intelligenz (LLM), das sie analysiert und automatisierte Empfehlungen erstellt. Diese Verarbeitung ist erforderlich, um Ihnen das Diagnoseergebnis bereitzustellen, und erfolgt nur, wenn Sie sich für die Nutzung dieses Tools entscheiden. Wenn Sie nicht möchten, dass Ihre Daten mittels künstlicher Intelligenz verarbeitet werden, nutzen Sie bitte Diagnostic Go nicht; unsere übrigen Dienste und Formulare sind davon nicht betroffen."
+  },
+  "metadata": {
+    "home": {
+      "title": "Maßgeschneiderte Softwareentwicklung",
+      "description": "Bei LyraTech entwickeln wir maßgeschneiderte Software: KI-gestützte Automatisierung, Festpreisprojekte und dedizierte Teams. Wir verwandeln Ihre Idee in ein echtes digitales Produkt."
+    },
+    "aboutUs": {
+      "title": "Über Uns",
+      "description": "Lernen Sie das Team hinter LyraTech kennen: brillante Köpfe, die Ideen in außergewöhnliche digitale Lösungen verwandeln, aus Querétaro, Mexiko."
+    },
+    "services": {
+      "title": "Softwareentwicklungsdienste",
+      "description": "Prozessautomatisierung, Festpreisprojekte und dedizierte Teams. Technologie, die Ihr Unternehmen transformiert, von der Idee bis zum Launch."
+    },
+    "portfolio": {
+      "title": "Unser Projektportfolio",
+      "description": "Entdecken Sie die Projekte, die wir realisiert haben: Fintech-Apps, Eventplattformen, Unternehmenswebsites und weitere erfolgreiche digitale Lösungen."
+    },
+    "contact": {
+      "title": "Kontaktieren Sie Uns",
+      "description": "Haben Sie ein Projekt im Kopf? Kontaktieren Sie uns und lassen Sie uns Ihre Idee in eine echte digitale Lösung verwandeln. Antwort innerhalb von 24 Stunden."
+    },
+    "legal": {
+      "title": "AGB und Datenschutz",
+      "description": "Lesen Sie die Allgemeinen Geschäftsbedingungen und die Datenschutzerklärung von LyraTech für die Nutzung unserer Website und Dienste."
+    }
   }
 }

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -360,6 +360,11 @@
     "resources4": "Legal",
     "copyright": "© {year} LyraTech. All rights reserved."
   },
+  "notFound": {
+    "badge": "Page not found",
+    "description": "Sorry, we couldn't find the page you're looking for. The link may be broken or the page may have moved.",
+    "button": "Back to home"
+  },
   "terms": {
     "title": "Terms and Conditions",
     "lastUpdated": "Last updated: July 2026",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -55,6 +55,7 @@
     "locale": "{locale, select, es {🇪🇸 Español} en {🇬🇧 English} de {🇩🇪 Deutsch} fr {🇫🇷 Français} other {Unknown}}"
   },
   "buttonLanguage": {
+    "flagAlt": "{label} flag",
     "Spanish": "Spanish",
     "English": "English",
     "German": "German",
@@ -105,6 +106,8 @@
     "titlePurple": "ideas",
     "titleBlack2": "into digital realities",
     "description": "At LyraTech we don't just write code, we create experiences that connect, inspire and generate real value. We are a multidisciplinary team passionate about solving complex problems with elegant and scalable solutions.",
+    "photoTeamAlt": "The Lyratech team at work",
+    "photoWorkspaceAlt": "The Lyratech workspace",
     "feat1Title": "Passion",
     "feat1Desc": "We love what we do and it shows in every line of code",
     "feat2Title": "Precision",
@@ -122,6 +125,7 @@
   },
   "teamSection": {
     "title": "Our team",
+    "photoAlt": "Photo of {name}",
     "desc1": "Visionary strategist who turns ideas into high-impact digital products.",
     "desc2": "Orchestrates processes and teams so every project ships on time with excellence.",
     "desc3": "Architect of solid, scalable, and cutting-edge technological solutions.",
@@ -194,6 +198,7 @@
     "verMas": "Read more"
   },
   "portfolioGrid": {
+    "sectionTitle": "All Projects",
     "filterAll": "All",
     "filterWeb": "Web",
     "filterMobile": "Mobile",
@@ -396,5 +401,31 @@
     "section5Body": "We retain your data only for as long as necessary to fulfill the purpose for which it was collected, or until you request its deletion. We apply reasonable technical and organizational measures to protect your information from unauthorized access, loss, or misuse. We do not share or sell your data to third parties for commercial purposes; we do use external providers that process data on our behalf to deliver the service: OpenRouter (to generate the diagnostic's AI analysis) and Resend (to send emails), each under their own data protection policies. These transfers are necessary to provide the service you requested.",
     "section6Title": "6. Use of artificial intelligence in the diagnostic",
     "section6Body": "To generate your strategic diagnostic, Diagnostic Go sends the answers you share to an artificial intelligence (LLM) model, which analyzes them and produces automated recommendations. This processing is necessary to provide you with the diagnostic result and only takes place when you choose to use this tool. If you do not want your data processed using artificial intelligence, please do not use Diagnostic Go; our other services and forms are not affected."
+  },
+  "metadata": {
+    "home": {
+      "title": "Custom Software Development",
+      "description": "At LyraTech we build custom software: AI-powered automation, fixed-price projects, and dedicated teams. We turn your idea into a real digital product."
+    },
+    "aboutUs": {
+      "title": "About Us",
+      "description": "Meet the team behind LyraTech: brilliant minds turning ideas into extraordinary digital solutions, from Querétaro, Mexico."
+    },
+    "services": {
+      "title": "Software Development Services",
+      "description": "Process automation, fixed-price projects, and dedicated teams. Technology that transforms your business, from idea to launch."
+    },
+    "portfolio": {
+      "title": "Our Project Portfolio",
+      "description": "Explore the projects we've built: fintech apps, event platforms, corporate websites, and more successful digital solutions."
+    },
+    "contact": {
+      "title": "Contact Us",
+      "description": "Have a project in mind? Reach out and let's talk about turning your idea into a real digital solution. We reply within 24 hours."
+    },
+    "legal": {
+      "title": "Terms & Privacy Policy",
+      "description": "Read LyraTech's Terms and Conditions and Privacy Policy for using our website and services."
+    }
   }
 }

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -360,6 +360,11 @@
     "resources4": "Legal",
     "copyright": "© {year} LyraTech. Todos los derechos reservados."
   },
+  "notFound": {
+    "badge": "Página no encontrada",
+    "description": "Lo sentimos, no pudimos encontrar la página que buscas. Puede que el enlace esté roto o que la página haya sido movida.",
+    "button": "Volver al inicio"
+  },
   "terms": {
     "title": "Términos y Condiciones",
     "lastUpdated": "Última actualización: julio de 2026",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -55,6 +55,7 @@
     "locale": "{locale, select, es {🇪🇸 Español} en {🇬🇧 English} de {🇩🇪 Deutsch} fr {🇫🇷 Français} other {Unknown}}"
   },
   "buttonLanguage": {
+    "flagAlt": "Bandera de {label}",
     "Spanish": "Español",
     "English": "Inglés",
     "German": "Alemán",
@@ -105,6 +106,8 @@
     "titlePurple": "ideas",
     "titleBlack2": "en realidades digitales",
     "description": "En LyraTech no solo escribimos código, creamos experiencias que conectan, inspiran y generan valor real. Somos un equipo multidisciplinario apasionado por resolver problemas complejos con soluciones elegantes y escalables.",
+    "photoTeamAlt": "Equipo de Lyratech trabajando",
+    "photoWorkspaceAlt": "Espacio de trabajo de Lyratech",
     "feat1Title": "Pasión",
     "feat1Desc": "Amamos lo que hacemos y se nota en cada línea de código",
     "feat2Title": "Precisión",
@@ -122,6 +125,7 @@
   },
   "teamSection": {
     "title": "Nuestro equipo",
+    "photoAlt": "Foto de {name}",
     "desc1": "Estratega visionario que convierte ideas en productos digitales de alto impacto.",
     "desc2": "Orquesta procesos y equipos para que cada proyecto llegue a tiempo y con excelencia.",
     "desc3": "Arquitecto de soluciones tecnológicas sólidas, escalables y a la vanguardia.",
@@ -194,6 +198,7 @@
     "verMas": "Leer más"
   },
   "portfolioGrid": {
+    "sectionTitle": "Todos los proyectos",
     "filterAll": "Todos",
     "filterWeb": "Web",
     "filterMobile": "Móvil",
@@ -396,5 +401,31 @@
     "section5Body": "Conservamos tus datos únicamente durante el tiempo necesario para cumplir con la finalidad para la que fueron recabados, o hasta que solicites su eliminación. Aplicamos medidas técnicas y organizativas razonables para proteger tu información contra accesos no autorizados, pérdida o uso indebido. No compartimos ni vendemos tus datos a terceros con fines comerciales; sí utilizamos proveedores externos que procesan datos por nuestra cuenta para poder ofrecerte el servicio: OpenRouter (para generar el análisis de inteligencia artificial del diagnóstico) y Resend (para el envío de correos electrónicos), cada uno bajo su propia política de protección de datos. Estas transferencias son necesarias para prestarte el servicio que solicitas.",
     "section6Title": "6. Uso de inteligencia artificial en el diagnóstico",
     "section6Body": "Para generar tu diagnóstico estratégico, la herramienta Diagnostic Go envía las respuestas que compartes a un modelo de inteligencia artificial (LLM) que las analiza y produce recomendaciones automatizadas. Este procesamiento es necesario para ofrecerte el resultado del diagnóstico y se realiza únicamente cuando decides usar esta herramienta. Si no deseas que tus datos sean procesados mediante inteligencia artificial, te pedimos no utilizar Diagnostic Go; el resto de nuestros servicios y formularios no se ven afectados."
+  },
+  "metadata": {
+    "home": {
+      "title": "Desarrollo de Software a la Medida",
+      "description": "En LyraTech creamos software a la medida: automatizaciones con IA, proyectos a precio fijo y equipos dedicados. Convertimos tu idea en una solución digital real."
+    },
+    "aboutUs": {
+      "title": "Sobre Nosotros",
+      "description": "Conoce al equipo detrás de LyraTech: mentes brillantes que transforman ideas en soluciones digitales extraordinarias, desde Querétaro, México."
+    },
+    "services": {
+      "title": "Servicios de Desarrollo de Software",
+      "description": "Automatización de procesos, proyectos a precio fijo y equipos dedicados. Tecnología que transforma tu negocio, desde la idea hasta el lanzamiento."
+    },
+    "portfolio": {
+      "title": "Portafolio de Proyectos",
+      "description": "Descubre los proyectos que hemos desarrollado: apps financieras, plataformas de eventos, sitios corporativos y más soluciones digitales exitosas."
+    },
+    "contact": {
+      "title": "Contáctanos",
+      "description": "¿Tienes un proyecto en mente? Escríbenos y hablemos de cómo convertir tu idea en una solución digital real. Respondemos en menos de 24 horas."
+    },
+    "legal": {
+      "title": "Términos y Aviso de Privacidad",
+      "description": "Consulta los Términos y Condiciones y el Aviso de Privacidad de LyraTech para el uso de nuestro sitio web y servicios."
+    }
   }
 }

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -360,6 +360,11 @@
     "resources4": "Mentions légales",
     "copyright": "© {year} LyraTech. Tous droits réservés."
   },
+  "notFound": {
+    "badge": "Page introuvable",
+    "description": "Désolé, nous n'avons pas trouvé la page que vous cherchez. Le lien est peut-être rompu ou la page a été déplacée.",
+    "button": "Retour à l'accueil"
+  },
   "terms": {
     "title": "Conditions Générales",
     "lastUpdated": "Dernière mise à jour : juillet 2026",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -55,6 +55,7 @@
     "locale": "{locale, select, es {🇪🇸 Español} en {🇬🇧 English} de {🇩🇪 Deutsch} fr {🇫🇷 Français} other {Unknown}}"
   },
   "buttonLanguage": {
+    "flagAlt": "Drapeau {label}",
     "Spanish": "Espagnol",
     "English": "Anglais",
     "German": "Allemand",
@@ -105,6 +106,8 @@
     "titlePurple": "idées",
     "titleBlack2": "en réalités numériques",
     "description": "Chez LyraTech, nous ne faisons pas que coder, nous créons des expériences qui connectent, inspirent et génèrent une valeur réelle. Nous sommes une équipe multidisciplinaire passionnée.",
+    "photoTeamAlt": "L'équipe Lyratech au travail",
+    "photoWorkspaceAlt": "L'espace de travail Lyratech",
     "feat1Title": "Passion",
     "feat1Desc": "Nous aimons ce que nous faisons et cela se voit dans chaque ligne de code",
     "feat2Title": "Précision",
@@ -122,6 +125,7 @@
   },
   "teamSection": {
     "title": "Notre équipe",
+    "photoAlt": "Photo de {name}",
     "desc1": "Stratège visionnaire qui transforme les idées en produits numériques à fort impact.",
     "desc2": "Orchestre les processus et les équipes pour que chaque projet soit livré à temps et avec excellence.",
     "desc3": "Architecte de solutions technologiques solides, évolutives et à la pointe.",
@@ -194,6 +198,7 @@
     "verMas": "Lire plus"
   },
   "portfolioGrid": {
+    "sectionTitle": "Tous les Projets",
     "filterAll": "Tous",
     "filterWeb": "Web",
     "filterMobile": "Mobile",
@@ -396,5 +401,31 @@
     "section5Body": "Nous conservons vos données uniquement pendant la durée nécessaire pour atteindre la finalité pour laquelle elles ont été collectées, ou jusqu'à ce que vous demandiez leur suppression. Nous appliquons des mesures techniques et organisationnelles raisonnables pour protéger vos informations contre tout accès non autorisé, perte ou usage abusif. Nous ne partageons ni ne vendons vos données à des tiers à des fins commerciales ; nous utilisons des prestataires externes qui traitent des données pour notre compte afin de fournir le service : OpenRouter (pour générer l'analyse d'intelligence artificielle du diagnostic) et Resend (pour l'envoi d'e-mails), chacun selon sa propre politique de protection des données. Ces transferts sont nécessaires pour vous fournir le service demandé.",
     "section6Title": "6. Utilisation de l'intelligence artificielle dans le diagnostic",
     "section6Body": "Pour générer votre diagnostic stratégique, Diagnostic Go envoie les réponses que vous partagez à un modèle d'intelligence artificielle (LLM), qui les analyse et produit des recommandations automatisées. Ce traitement est nécessaire pour vous fournir le résultat du diagnostic et n'a lieu que lorsque vous choisissez d'utiliser cet outil. Si vous ne souhaitez pas que vos données soient traitées par intelligence artificielle, veuillez ne pas utiliser Diagnostic Go ; le reste de nos services et formulaires n'est pas concerné."
+  },
+  "metadata": {
+    "home": {
+      "title": "Développement de Logiciels sur Mesure",
+      "description": "Chez LyraTech, nous créons des logiciels sur mesure : automatisation par IA, projets à prix fixe et équipes dédiées. Nous transformons votre idée en solution numérique réelle."
+    },
+    "aboutUs": {
+      "title": "À Propos",
+      "description": "Découvrez l'équipe derrière LyraTech : des esprits brillants qui transforment des idées en solutions numériques extraordinaires, depuis Querétaro, au Mexique."
+    },
+    "services": {
+      "title": "Services de Développement Logiciel",
+      "description": "Automatisation des processus, projets à prix fixe et équipes dédiées. Une technologie qui transforme votre entreprise, de l'idée au lancement."
+    },
+    "portfolio": {
+      "title": "Portefeuille de Projets",
+      "description": "Découvrez les projets que nous avons réalisés : applications fintech, plateformes d'événements, sites corporatifs et bien d'autres solutions numériques."
+    },
+    "contact": {
+      "title": "Contactez-nous",
+      "description": "Vous avez un projet en tête ? Contactez-nous et parlons de transformer votre idée en solution numérique réelle. Réponse sous 24 heures."
+    },
+    "legal": {
+      "title": "Conditions Générales et Confidentialité",
+      "description": "Consultez les Conditions Générales et la Politique de Confidentialité de LyraTech pour l'utilisation de notre site et de nos services."
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes the 3 SEO gaps found in the audit: duplicate metadata across pages, broken heading hierarchy, and generic/untranslated alt text. Covers all 4 locales (es/en/fr/de).

| Area | Before | After |
|---|---|---|
| **Metadata** | A single static `<title>`/`<meta description>` shared across 20+ page×locale combinations — Google showed duplicate/generic snippets (see the `/nosotros` screenshot) | Per-page, per-locale `generateMetadata` on home, about-us, services, portfolio, contact, and legal, with `canonical` and `hreflang` for each locale |
| **Headings** | Home and `/dev` had 3 `<h1>` tags; `/legal` had 2 `<h1>` tags; `/portfolio` jumped from `<h1>` straight to `<h3>` with no `<h2>`; the services cards duplicated the `<h3>` on both the front and back face | Exactly 1 `<h1>` per page; missing `<h2>` added; duplicate card heading removed |
| **Alt text** | Generic `"About Us"` alt reused on 2 different images; hardcoded English alt text (`AboutUsIntro`, language-switcher flags); decorative navbar notch mislabeled; team photos alt'd with just the name | Unique, translated alt text in all 4 locales; decorative images marked `alt=""` |